### PR TITLE
feat: add support for NpgsqlDbContextOptionsBuilder and DbContextOptionsBuilder

### DIFF
--- a/src/MccSoft.IntegreSql.EF/DatabaseInitialization/BaseDatabaseInitializer.cs
+++ b/src/MccSoft.IntegreSql.EF/DatabaseInitialization/BaseDatabaseInitializer.cs
@@ -74,7 +74,7 @@ public abstract class BaseDatabaseInitializer : IDatabaseInitializer
     )
         where TDbContext : DbContext
     {
-        string lastMigrationName = ContextHelper.GetLastMigrationName<TDbContext>() ?? "";
+        string lastMigrationName = ContextHelper.GetLastMigrationName<TDbContext>(useProvider: this) ?? "";
 
         return CreateDatabaseGetConnectionStringInternal(
             databaseSeeding?.Name

--- a/src/MccSoft.IntegreSql.EF/DatabaseInitialization/ContextHelper.cs
+++ b/src/MccSoft.IntegreSql.EF/DatabaseInitialization/ContextHelper.cs
@@ -13,10 +13,14 @@ public class ContextHelper
     /// Tries to create the DbContext using the passed factory method,
     /// or by using a constructor with DbContextOptions as a first argument and nulls as all the rest.
     /// </summary>
-    public static string? GetLastMigrationName<T>(Func<DbContextOptions<T>, T> factoryMethod = null)
+    public static string? GetLastMigrationName<T>(IUseProvider useProvider = null,
+        Func<DbContextOptions<T>, T> factoryMethod = null)
         where T : DbContext
     {
-        var dbContext = CreateDbContext(new NpgsqlDatabaseInitializer(), factoryMethod);
+        // Use the provided useProvider or create a default one
+        useProvider ??= new NpgsqlDatabaseInitializer();
+
+        var dbContext = CreateDbContext(useProvider, factoryMethod);
         var assemblyMigrations = dbContext.Database.GetMigrations();
         return assemblyMigrations.LastOrDefault();
     }


### PR DESCRIPTION
Adds that ability to configure the `NpgsqlDbContext` and `DbContext`. In my case these are needed to add support for PostGIS and some naming conventions.

This is how I call it in my own code:
```csharp
npgsqlOptionsAction: x => x.UseNetTopologySuite(),
optionsAction: builder => builder.UseSnakeCaseNamingConvention().UseExceptionProcessor()
```

NOTE: I don't fully understand the architecture of the code, so I am not sure if the code is structured correctly.